### PR TITLE
[shell_script] go_back.sh has modified.

### DIFF
--- a/shell_scripts/go_back.sh
+++ b/shell_scripts/go_back.sh
@@ -1,7 +1,7 @@
 # Author Gokulakannan
 # Date: 22-05-2018
-# ~/go_back.sh 3
-# filename no-of-directory-to-back
+# . ~/go_back.sh 3
+# . filename no-of-directory-to-back
 
 COUNT=$1;
 


### PR DESCRIPTION
The misleading bash command has fixed. For example, need to run command like below,

alias b=". ~/go_back.sh"

Earlier, the dot(.) is missing in the command

Signed-off-by: gokulakannant <gokulakannanthangaraji@gmail.com>